### PR TITLE
Es prototyping

### DIFF
--- a/gollum_search.gemspec
+++ b/gollum_search.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   # Dependencies
   spec.add_dependency 'elasticsearch', '~> 7.15'
+  #spec.add_dependency 'elasticsearch-persistence', '~> 7.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'dotenv', '~> 2.7'

--- a/lib/gollum_search/elasticsearch/client.rb
+++ b/lib/gollum_search/elasticsearch/client.rb
@@ -12,7 +12,10 @@ module GollumSearch
       def self.connection()
         @conn ||= ::Elasticsearch::Client.new(
           url: ENV.fetch('ELASTICSEARCH_URL') { raise 'You must define ELASTICSEARCH_URL in your environment.' },
-          transport_options: {request: {timeout: timeout}, headers: {content_type: 'application/json'}},
+          transport_options: {
+            request: {timeout: timeout},
+            headers: {content_type: 'application/json'},
+          },
         )
       end
 

--- a/lib/gollum_search/elasticsearch/index.rb
+++ b/lib/gollum_search/elasticsearch/index.rb
@@ -4,7 +4,13 @@ module GollumSearch
   module Elasticsearch
     class Index
       def self.for_wiki(wiki)
+        @es ||= GollumSearch::Elasticsearch::Client.connection
+        wiki.pages.each do |page|
+          # Construct the proper payload for ES.
+          # Use Gollum::Elasticsearch::Client to push an index entry into ES, keyed on the page name.
 
+          # TODO: Push into ES in batches.
+        end
       end
     end
   end

--- a/lib/gollum_search/elasticsearch/wiki_page.rb
+++ b/lib/gollum_search/elasticsearch/wiki_page.rb
@@ -1,0 +1,16 @@
+module Gollum
+  module Elasticsearch
+    class WikiPage
+
+      def find(name)
+      end
+
+      def search_data
+      end
+
+    end
+  end
+end
+
+# Intent here is to create a two-part persistence layer (Data object + Repository pattern) that links ES index records with Gollum::Page objects: https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/7.x/persistence.html
+

--- a/playground.rb
+++ b/playground.rb
@@ -1,0 +1,56 @@
+# This is a minimal proof of concept for taking git data and
+# loading it into Elasticsearch.
+
+# Run `dce gollum ruby playground.rb` to index the repo into Elasticsearch.
+# Then visit: http://localhost:9200/_search?q=bilbo or ?q=ring
+
+
+require 'bundler/setup'
+require 'elasticsearch'
+require 'gollum-lib'
+
+es_conn = Elasticsearch::Client.new(
+  url: ENV.fetch('ELASTICSEARCH_URL') { raise 'You must define ELASTICSEARCH_URL in your environment.' },
+  transport_options: {
+    request: {timeout: 5},
+    headers: {content_type: 'application/json'},
+  },
+)
+wiki_path = '/app/test/examples/lotr.git'
+wiki = Gollum::Wiki.new(wiki_path)
+
+wiki.pages.each do |page|
+  pp page
+  payload = {
+    title: page.title,
+    toc: page.toc_data,
+    tags: page.metadata.fetch('tags', []),
+    version_short: page.version_short,
+    content: page.text_data,
+  }
+  es_conn.index(
+    index: 'wiki',
+    type: 'page',
+    id: page.name,
+    body: payload,
+  )
+end
+
+# TODO: Convert this example into the already stubbed out GollumSearch::Elasticsearch::* classes, and integrate with the plugin at large.
+# - Write a class/method that takes a single Wiki.page and indexes it in ES. Also consider monkeypatch in a Gollum::Page.search_data method that returns ES formatted data for easier use?
+
+# - Write a Rake script that will batch-index an entire repo from a given file path (like above but "official".)
+# - Write a search method that returns results compatible with Wiki.search() results.
+# Figure out how to monkeypatch our search method on top of Gollum::Wiki.search: https://github.com/gollum/gollum-lib/blob/master/lib/gollum-lib/wiki.rb#L492 (This would be "easier" and less invasive than overriding the /gollum/search route.)
+# Make this plugin able to register Gollum hooks for after_commit (to write the updated page into the ES index) and `Gollum::Hook.register(:post_wiki_initialize, :hook_id)` (we can save a reference to that wiki instance for use), and update "installation" docs for how to do that in your own Gollum wiki.
+
+
+# Refs:
+# - [Using raw Elasticsearch client](https://rubydoc.info/gems/elasticsearch-api)
+# - [gollumb-lib's Page class](https://github.com/gollum/gollum-lib/blob/master/lib/gollum-lib/page.rb)
+# - [ES Repository pattern](https://github.com/elastic/elasticsearch-rails/tree/main/elasticsearch-persistence#the-repository-pattern)
+# - [Example ES Sinatra app](https://github.com/elastic/elasticsearch-rails/blob/main/elasticsearch-persistence/examples/notes/application.rb)
+# - []()
+# - []()
+# - []()
+# - []()


### PR DESCRIPTION
Expands a bit on the existing stubbed Elasticsearch classes a bit, but the main attraction is `./playground.rb`, which demonstrates the ability to batch-index an entire git repo (based solely on a file path) into an Elasticsearch server.

The bottom of `playground.rb` has all of the next TODO steps.